### PR TITLE
feat: replace imagedelivery links with vibankruptcy paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,15 +1,20 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>CLIPcherry - Coming Soon</title>
-  <style>
-    body {
-      display: flex;
-      justify-content: center;
-      align-items: center;
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CLIPcherry - Coming Soon</title>
+    <link rel="preconnect" href="https://vibankruptcy.com">
+    <link rel="icon" href="https://vibankruptcy.com/favicon.ico">
+    <link rel="manifest" href="/site.webmanifest">
+    <meta property="og:image" content="https://vibankruptcy.com/images/og.png">
+    <meta name="twitter:image" content="https://vibankruptcy.com/images/twitter.png">
+    <style>
+      body {
+        display: flex;
+        justify-content: center;
+        align-items: center;
       height: 100vh;
       margin: 0;
       font-family: Arial, sans-serif;

--- a/scripts/fix-cloudflare-images.js
+++ b/scripts/fix-cloudflare-images.js
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const rootDir = process.cwd();
+const cfImageRegex = /https:\/\/imagedelivery\.net\/([A-Za-z0-9_-]+\/[A-Za-z0-9_-]+\/[A-Za-z0-9_-]+(?:\/public)?)/g;
+
+function walk(dir) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === 'node_modules' || entry.name === '.git') continue;
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(fullPath);
+    } else if (/\.(html|xml|json|webmanifest)$/.test(entry.name)) {
+      processFile(fullPath);
+    }
+  }
+}
+
+function ensureBackup(file) {
+  const bak = file + '.bak';
+  if (!fs.existsSync(bak)) {
+    fs.copyFileSync(file, bak);
+  }
+}
+
+function toAbsolute(url) {
+  if (url.startsWith('https://vibankruptcy.com')) return url;
+  if (url.startsWith('https://')) return url;
+  if (url.startsWith('/')) return 'https://vibankruptcy.com' + url;
+  return 'https://vibankruptcy.com/' + url;
+}
+
+function processFile(file) {
+  let content = fs.readFileSync(file, 'utf8');
+  const original = content;
+
+  // Replace Cloudflare Images URLs
+  content = content.replace(cfImageRegex, 'https://vibankruptcy.com/cdn-cgi/imagedelivery/$1');
+
+  // Replace preconnect tags
+  content = content.replace(/<link\s+rel=["']preconnect["']\s+href=["']https:\/\/imagedelivery\.net["'][^>]*>/gi,
+    '<link rel="preconnect" href="https://vibankruptcy.com">');
+
+  // Update og:image and twitter:image
+  content = content.replace(/(<meta\s+(?:property|name)=["'](?:og:image|twitter:image)["']\s+content=["'])(?!https:\/\/vibankruptcy\.com)([^"']+)/gi,
+    (m, p1, url) => p1 + toAbsolute(url));
+
+  // Update favicon links
+  content = content.replace(/(<link[^>]+rel=["'][^"']*icon[^"']*["'][^>]*href=["'])(?!https:\/\/vibankruptcy\.com)([^"']+)/gi,
+    (m, p1, url) => p1 + toAbsolute(url));
+
+  if (/\.(json|webmanifest)$/.test(file)) {
+    try {
+      const json = JSON.parse(content);
+      if (Array.isArray(json.icons)) {
+        json.icons = json.icons.map(icon => {
+          if (icon.src) {
+            icon.src = icon.src.replace(cfImageRegex, 'https://vibankruptcy.com/cdn-cgi/imagedelivery/$1');
+            icon.src = toAbsolute(icon.src);
+          }
+          return icon;
+        });
+      }
+      content = JSON.stringify(json, null, 2);
+    } catch (e) {
+      // ignore parse errors
+    }
+  }
+
+  if (content !== original) {
+    ensureBackup(file);
+    fs.writeFileSync(file, content);
+    console.log('Updated', file);
+  }
+}
+
+walk(rootDir);

--- a/site.webmanifest
+++ b/site.webmanifest
@@ -1,0 +1,16 @@
+{
+  "name": "VI Bankruptcy",
+  "short_name": "VIBankruptcy",
+  "icons": [
+    {
+      "src": "https://vibankruptcy.com/icons/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "https://vibankruptcy.com/icons/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add fix-cloudflare-images script to rewrite imagedelivery URLs, update icons, and handle meta images
- add site.webmanifest and point icons to vibankruptcy.com
- update index.html metadata and icon links to vibankruptcy paths

## Testing
- `node scripts/fix-cloudflare-images.js`


------
https://chatgpt.com/codex/tasks/task_e_68a012ae371c8321b40bd7d6d013d241